### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -133,14 +133,14 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unwrapped"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "unwrapped-derive",
 ]
 
 [[package]]
 name = "unwrapped-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bon",
  "darling",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "unwrapped-derive"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "syn",
  "unwrapped-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 publish = true
 readme = "README.md"
 repository = "https://github.com/stayhydated/unwrapped"
-version = "0.1.0"
+version = "0.1.1"
 
 [workspace.dependencies]
 bon = "3.6.4"
@@ -17,8 +17,8 @@ darling = "0.20.10"
 proc-macro2 = "1.0.93"
 quote = "1.0.38"
 syn = "2.0.104"
-unwrapped-core = { path = "crates/unwrapped-core", version = "0.1.0" }
-unwrapped-derive = { path = "crates/unwrapped-derive", version = "0.1.0" }
+unwrapped-core = { path = "crates/unwrapped-core", version = "0.1.1" }
+unwrapped-derive = { path = "crates/unwrapped-derive", version = "0.1.1" }
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "deny" }

--- a/crates/unwrapped-core/CHANGELOG.md
+++ b/crates/unwrapped-core/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/stayhydated/unwrapped/compare/unwrapped-core-v0.1.0...unwrapped-core-v0.1.1) - 2025-07-02
+
+### Other
+
+- update Cargo.toml dependencies

--- a/crates/unwrapped-derive/CHANGELOG.md
+++ b/crates/unwrapped-derive/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/unwrapped/CHANGELOG.md
+++ b/crates/unwrapped/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/stayhydated/unwrapped/compare/unwrapped-v0.1.0...unwrapped-v0.1.1) - 2025-07-02
+
+### Other
+
+- .
+- .


### PR DESCRIPTION



## 🤖 New release

* `unwrapped-core`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `unwrapped-derive`: 0.1.0 -> 0.1.1
* `unwrapped`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `unwrapped-core`

<blockquote>

## [0.1.1](https://github.com/stayhydated/unwrapped/compare/unwrapped-core-v0.1.0...unwrapped-core-v0.1.1) - 2025-07-02

### Other

- update Cargo.toml dependencies
</blockquote>


## `unwrapped`

<blockquote>

## [0.1.1](https://github.com/stayhydated/unwrapped/compare/unwrapped-v0.1.0...unwrapped-v0.1.1) - 2025-07-02

### Other

- .
- .
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).